### PR TITLE
Fix dark mode toggle text initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,8 +82,8 @@
     const savedMode = localStorage.getItem('mode');
     if (savedMode === 'dark') {
       body.classList.add('dark-mode');
-      toggle.textContent = 'Light Mode';
     }
+    toggle.textContent = body.classList.contains('dark-mode') ? 'Light Mode' : 'Dark Mode';
     toggle.addEventListener('click', () => {
       body.classList.toggle('dark-mode');
       localStorage.setItem('mode', body.classList.contains('dark-mode') ? 'dark' : 'light');


### PR DESCRIPTION
## Summary
- update dark mode initialization logic so button text matches saved theme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684702874b3083228679b4be6f513c1f