### PR TITLE
Sort events chronologically

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,6 +121,26 @@
       return str;
     }
 
+    function parseStartDate(str) {
+      if (typeof str === 'string') {
+        const dp = /^Date\(\s*([0-9]{4})\s*,\s*([0-9]{1,2})\s*,\s*([0-9]{1,2})\s*\)/.exec(str);
+        if (dp) {
+          const [, y, m, d] = dp;
+          return new Date(y, m, d);
+        }
+      }
+      const full = /^([0-9]{4})-([0-9]{2})-([0-9]{2})/.exec(str);
+      if (full) {
+        return new Date(full[1], full[2] - 1, full[3]);
+      }
+      const ym = /^([0-9]{4})-([0-9]{2})/.exec(str);
+      if (ym) {
+        return new Date(ym[1], ym[2] - 1);
+      }
+      const d = new Date(str);
+      return isNaN(d) ? new Date(0) : d;
+    }
+
     function fetchEvents() {
       fetch(url)
         .then(res => res.text())
@@ -136,6 +156,7 @@
             temas: (r.c[8]?.v || '').split(/\s+/).map(t => t.replace(/^#/, '')).filter(t => t),
             preco: r.c[9]?.v ? parseFloat(r.c[9].v) : null
           }));
+          events.sort((a, b) => parseStartDate(a.data_inicio) - parseStartDate(b.data_inicio));
           populateFilters();
           populateCloud();
           applyFilters();


### PR DESCRIPTION
## Summary
- add a helper to parse event start dates
- sort fetched events by the parsed start date before rendering

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684702e379248322802f7834df0f7e5c