### PR TITLE
Fix date locale

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,8 +117,8 @@
       if (m) {
         // constrói Date(year, monthIndex)
         const date = new Date(m[1], m[2] - 1);
-        // formata para "mês de ano" em pt-PT
-        return date.toLocaleDateString('pt-PT', { month: 'long', year: 'numeric' });
+        // format to "month year" in English
+        return date.toLocaleDateString('en', { month: 'long', year: 'numeric' });
       }
     
       // 3) fallback: devolve o original


### PR DESCRIPTION
## Summary
- render month names in English instead of Portuguese

## Testing
- `node -e "console.log(new Date(2025,9).toLocaleDateString('en', {month:'long', year:'numeric'}))"`

------
https://chatgpt.com/codex/tasks/task_e_68470ae9de4c8322be9013a40598ba52