### PR TITLE
Fix month display bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,8 +182,8 @@
         const dp = /^Date\(\s*([0-9]{4})\s*,\s*([0-9]{1,2})\s*,\s*([0-9]{1,2})\s*\)/.exec(str);
         if (dp) {
           const [ , year, month, day ] = dp;
-          // monta "YYYY-MM-DD", garantindo dois dígitos no mês e no dia
-          const mm = month.padStart(2, '0');
+          // Google Sheets usa mês baseado em zero (0=Jan). Ajusta para 1-12
+          const mm = String(Number(month) + 1).padStart(2, '0');
           const dd = day.padStart(2, '0');
           str = `${year}-${mm}-${dd}`;
         }


### PR DESCRIPTION
## Summary
- adjust `formatMonthYear` to handle Google Sheets zero-based months correctly

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6848b44792888322bb777f079989b3cc