### PR TITLE
Fix overlay visibility on initial page load

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -227,6 +227,7 @@ function renderEvents(list) {
 
     const hideModal = () => {
       overlay.classList.add('hidden');
+      overlay.style.display = 'none';
       document.body.style.overflow = '';
     };
     // ensure hidden on load in case markup lacks the class
@@ -237,6 +238,7 @@ function renderEvents(list) {
       addEventLink.addEventListener('click', e => {
         e.preventDefault();
         overlay.classList.remove('hidden');
+        overlay.style.display = 'flex';
         document.body.style.overflow = 'hidden';
       });
 

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 
   <a href="#" id="add-event">Add Event</a>
 
-  <div id="submit-overlay" class="hidden">
+  <div id="submit-overlay" class="hidden" style="display:none;">
     <div class="overlay-content">
       <button id="close-overlay" class="close-button">&times;</button>
       <h1>Submit a Tech Event</h1>


### PR DESCRIPTION
## Summary
- hide the submit overlay with inline `style="display:none;"`
- toggle the overlay display from JavaScript when opening or closing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b326423748322839f8039295dffaf